### PR TITLE
Add PrefixScan and IndexScan to ModelBucket

### DIFF
--- a/morm/iterator.go
+++ b/morm/iterator.go
@@ -1,0 +1,83 @@
+package morm
+
+import (
+	"github.com/iov-one/weave"
+	"github.com/iov-one/weave/errors"
+)
+
+type ModelIterator interface {
+	// Valid returns whether the current position is valid.
+	// Once invalid, an Iterator is forever invalid.
+	Valid() bool
+
+	// Next moves the iterator to the next sequential key in the database, as
+	// defined by order of iteration.
+	//
+	// If Valid returns false, this method will panic.
+	Next() error
+
+	// Load reads the current value at the given key into the passed destination.
+	// This works much like "One" in ModelBucket
+	Load(dest Model) error
+
+	// Close releases the Iterator.
+	Close()
+}
+
+type idModelIterator struct {
+	iterator weave.Iterator
+}
+
+var _ ModelIterator = (*idModelIterator)(nil)
+
+func (i *idModelIterator) Valid() bool {
+	return i.iterator.Valid()
+}
+
+func (i *idModelIterator) Next() error {
+	return i.iterator.Next()
+}
+
+func (i *idModelIterator) Close() {
+	i.iterator.Close()
+}
+
+func (i *idModelIterator) Load(dest Model) error {
+	key := i.iterator.Key()
+	value := i.iterator.Value()
+
+	if err := dest.Unmarshal(value); err != nil {
+		return errors.Wrapf(err, "unmarshaling into %T", dest)
+	}
+	if err := dest.SetID(key); err != nil {
+		return errors.Wrap(err, "setting ID")
+	}
+	return nil
+}
+
+// prefixRange turns a prefix into (start, end) to create
+// and iterator
+func prefixRange(prefix []byte) ([]byte, []byte) {
+	// special case: no prefix is whole range
+	if len(prefix) == 0 {
+		return nil, nil
+	}
+
+	// copy the prefix and update last byte
+	end := make([]byte, len(prefix))
+	copy(end, prefix)
+	l := len(end) - 1
+	end[l]++
+
+	// wait, what if that overflowed?....
+	for end[l] == 0 && l > 0 {
+		l--
+		end[l]++
+	}
+
+	// okay, funny guy, you gave us FFF, no end to this range...
+	if l == 0 && end[0] == 0 {
+		end = nil
+	}
+	return prefix, end
+}

--- a/morm/model_bucket.go
+++ b/morm/model_bucket.go
@@ -52,7 +52,7 @@ type ModelBucket interface {
 	// The function returns a (possibly empty) iterator, which can
 	// load each model as it arrives.
 	// If reverse is true, iterates in descending order (highest value first),
-	// otherwise, it iterates in ascending order
+	// otherwise, it iterates in
 	PrefixScan(db weave.ReadOnlyKVStore, prefix []byte, reverse bool) (ModelIterator, error)
 
 	// ByIndex returns all objects that secondary index with given name and
@@ -160,7 +160,7 @@ func (mb *modelBucket) PrefixScan(db weave.ReadOnlyKVStore, prefix []byte, rever
 	var rawIter weave.Iterator
 	var err error
 
-	start, end := prefixRange(prefix)
+	start, end := prefixRange(mb.b.DBKey(prefix))
 	if reverse {
 		rawIter, err = db.ReverseIterator(start, end)
 		if err != nil {
@@ -173,7 +173,7 @@ func (mb *modelBucket) PrefixScan(db weave.ReadOnlyKVStore, prefix []byte, rever
 		}
 	}
 
-	return &idModelIterator{iterator: rawIter}, nil
+	return &idModelIterator{iterator: rawIter, bucketPrefix: mb.b.DBKey(nil)}, nil
 }
 
 func (mb *modelBucket) ByIndex(db weave.ReadOnlyKVStore, indexName string, key []byte, destination ModelSlicePtr) error {

--- a/morm/model_bucket_test.go
+++ b/morm/model_bucket_test.go
@@ -71,6 +71,41 @@ func TestModelBucketPutSequence(t *testing.T) {
 	assert.Equal(t, int64(222), c2.Count)
 }
 
+func TestModelBucketPrefixScan(t *testing.T) {
+	db := store.MemStore()
+
+	b := NewModelBucket("cnts", &Counter{})
+
+	cnts := []Counter{
+		Counter{Count: 1},
+		Counter{Count: 17},
+		Counter{Count: 11},
+		Counter{Count: 3},
+	}
+	for i := range cnts {
+		// make sure we point to value in array, so this ID gets set
+		err := b.Put(db, &cnts[i])
+		assert.Nil(t, err)
+	}
+
+	var loaded Counter
+	iter, err := b.PrefixScan(db, nil, false)
+	assert.Nil(t, err)
+	assert.Equal(t, true, iter.Valid())
+	err = iter.Load(&loaded)
+	assert.Nil(t, err)
+	assert.Equal(t, cnts[0], loaded)
+
+	err = iter.Next()
+	assert.Nil(t, err)
+	assert.Equal(t, true, iter.Valid())
+	err = iter.Load(&loaded)
+	assert.Nil(t, err)
+	assert.Equal(t, cnts[1], loaded)
+
+	iter.Close()
+}
+
 func TestModelBucketByIndex(t *testing.T) {
 	cases := map[string]struct {
 		IndexName  string

--- a/morm/model_bucket_test.go
+++ b/morm/model_bucket_test.go
@@ -117,18 +117,18 @@ func TestModelBucketPrefixScan(t *testing.T) {
 
 }
 
+func lexographicCountIndex(obj orm.Object) ([]byte, error) {
+	c, ok := obj.Value().(*Counter)
+	if !ok {
+		return nil, errors.Wrapf(errors.ErrType, "%T", obj.Value())
+	}
+	res := make([]byte, 8)
+	binary.BigEndian.PutUint64(res, uint64(c.Count))
+	return res, nil
+}
+
 func TestModelBucketIndexScanUnique(t *testing.T) {
 	db := store.MemStore()
-
-	lexographicCountIndex := func(obj orm.Object) ([]byte, error) {
-		c, ok := obj.Value().(*Counter)
-		if !ok {
-			return nil, errors.Wrapf(errors.ErrType, "%T", obj.Value())
-		}
-		res := make([]byte, 8)
-		binary.BigEndian.PutUint64(res, uint64(c.Count))
-		return res, nil
-	}
 
 	b := NewModelBucket("cnts", &Counter{}, WithIndex("counter", lexographicCountIndex, true))
 
@@ -180,6 +180,90 @@ func TestModelBucketIndexScanUnique(t *testing.T) {
 	assert.Nil(t, err)
 	// should get second-highest value
 	assert.Equal(t, Counter{ID: weavetest.SequenceID(2), Count: 17}, loaded)
+
+	iter.Close()
+}
+
+func TestModelBucketIndexScanMulti(t *testing.T) {
+	db := store.MemStore()
+
+	b := NewModelBucket("cnts", &Counter{}, WithIndex("counter", lexographicCountIndex, false))
+
+	cnts := []Counter{
+		Counter{Count: 1},
+		Counter{Count: 17},
+		Counter{Count: 3},
+		Counter{Count: 8},
+		Counter{Count: 17},
+		Counter{Count: 3},
+	}
+	for i := range cnts {
+		// make sure we point to value in array, so this ID gets set
+		err := b.Put(db, &cnts[i])
+		assert.Nil(t, err)
+	}
+
+	var loaded Counter
+	iter, err := b.IndexScan(db, "counter", nil, false)
+	assert.Nil(t, err)
+	assert.Equal(t, true, iter.Valid())
+	err = iter.Load(&loaded)
+	assert.Nil(t, err)
+	// should get lowest value
+	assert.Equal(t, Counter{ID: weavetest.SequenceID(1), Count: 1}, loaded)
+
+	err = iter.Next()
+	assert.Nil(t, err)
+	assert.Equal(t, true, iter.Valid())
+	err = iter.Load(&loaded)
+	assert.Nil(t, err)
+	// should get second-lowest value (3)
+	assert.Equal(t, Counter{ID: weavetest.SequenceID(3), Count: 3}, loaded)
+
+	err = iter.Next()
+	assert.Nil(t, err)
+	assert.Equal(t, true, iter.Valid())
+	err = iter.Load(&loaded)
+	assert.Nil(t, err)
+	// should get 3 a second time
+	assert.Equal(t, Counter{ID: weavetest.SequenceID(6), Count: 3}, loaded)
+
+	// repeated loads should not advance
+	err = iter.Load(&loaded)
+	assert.Nil(t, err)
+	// should get 3 a second time
+	assert.Equal(t, Counter{ID: weavetest.SequenceID(6), Count: 3}, loaded)
+	err = iter.Load(&loaded)
+	assert.Nil(t, err)
+	// should get 3 a second time
+	assert.Equal(t, Counter{ID: weavetest.SequenceID(6), Count: 3}, loaded)
+
+	iter.Close()
+
+	// counting backwards
+	iter, err = b.IndexScan(db, "counter", nil, true)
+	assert.Nil(t, err)
+	assert.Equal(t, true, iter.Valid())
+	err = iter.Load(&loaded)
+	assert.Nil(t, err)
+	// should get lowest value
+	assert.Equal(t, Counter{ID: weavetest.SequenceID(2), Count: 17}, loaded)
+
+	err = iter.Next()
+	assert.Nil(t, err)
+	assert.Equal(t, true, iter.Valid())
+	err = iter.Load(&loaded)
+	assert.Nil(t, err)
+	// should get second-lowest value (3)
+	assert.Equal(t, Counter{ID: weavetest.SequenceID(5), Count: 17}, loaded)
+
+	err = iter.Next()
+	assert.Nil(t, err)
+	assert.Equal(t, true, iter.Valid())
+	err = iter.Load(&loaded)
+	assert.Nil(t, err)
+	// should get 3 a second time
+	assert.Equal(t, Counter{ID: weavetest.SequenceID(4), Count: 8}, loaded)
 
 	iter.Close()
 


### PR DESCRIPTION
Combined with work on LazyIterators (https://github.com/iov-one/weave/pull/762), we can now easily get the first or last items in any set.. based on id or any seconday index. This can be used to eg. find the highest price for bid or lowest price for ask offers on a given orderbook. But can be used in many situations, just like the sort and limit operators in SQL.