### PR TITLE
Create app.go

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -52,3 +52,10 @@ func QueryRouter() weave.QueryRouter {
 	)
 	return r
 }
+
+// Stack wires up a standard router with a standard decorator
+// chain. This can be passed into BaseApp.
+func Stack(minFee coin.Coin) weave.Handler {
+	authFn := Authenticator()
+	return Chain(authFn, minFee).WithHandler(Router(authFn))
+}

--- a/app/app.go
+++ b/app/app.go
@@ -36,6 +36,7 @@ func Chain(authFn x.Authenticator, minFee coin.Coin) app.Decorators {
 		utils.NewSavepoint().OnCheck(),
 		sigs.NewDecorator(),
 		multisig.NewDecorator(authFn),
+		utils.NewSavepoint().OnDeliver(),
 		msgfee.NewFeeDecorator(),
 	)
 }

--- a/app/app.go
+++ b/app/app.go
@@ -1,0 +1,13 @@
+package app
+
+import (	
+	"github.com/iov-one/weave/x"
+	"github.com/iov-one/weave/x/sigs"
+	"github.com/iov-one/weave/x/multisig"
+)
+
+// Authenticator returns authentication with multisigs 
+// and public key signatues 
+func Authenticator() x.Authenticator {
+	return x.ChainAuth(sigs.Authenticate{}, multisig.Authenticate{})
+}

--- a/app/app.go
+++ b/app/app.go
@@ -1,13 +1,33 @@
 package app
 
-import (	
+import (
+	"github.com/iov-one/weave/app"
+	"github.com/iov-one/weave/coin"
 	"github.com/iov-one/weave/x"
-	"github.com/iov-one/weave/x/sigs"
 	"github.com/iov-one/weave/x/multisig"
+	"github.com/iov-one/weave/x/sigs"
+	"github.com/iov-one/weave/x/utils"
+	"github.com/iov-one/weave/x/msgfee"
 )
 
-// Authenticator returns authentication with multisigs 
-// and public key signatues 
+// Authenticator returns authentication with multisigs
+// and public key signatues
 func Authenticator() x.Authenticator {
 	return x.ChainAuth(sigs.Authenticate{}, multisig.Authenticate{})
+}
+
+// Chain returns a chain of decorators, to handle authentication,
+// fees, logging, and recovery
+func Chain(authFn x.Authenticator, minFee coin.Coin) app.Decorators {
+	
+	// TODO implement orderbook controller
+	return app.ChainDecorators(
+		utils.NewLogging(),
+		utils.NewRecovery(),
+		utils.NewKeyTagger(),
+		utils.NewSavepoint().OnCheck(),
+		sigs.NewDecorator(),
+		multisig.NewDecorator(authFn),
+		msgfee.NewFeeDecorator(),
+	)
 }

--- a/app/app.go
+++ b/app/app.go
@@ -1,10 +1,11 @@
 package app
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"strings"
-	
+
 	"github.com/iov-one/weave"
 	"github.com/iov-one/weave/app"
 	"github.com/iov-one/weave/coin"
@@ -86,4 +87,19 @@ func CommitKVStore(dbPath string) (weave.CommitKVStore, error) {
 	dir := filepath.Dir(path)
 	name := filepath.Base(path)
 	return iavl.NewCommitStore(dir, name), nil
+}
+
+// Application constructs a basic ABCI application with
+// the given arguments. 
+func Application(name string, h weave.Handler,
+	tx weave.TxDecoder, dbPath string, debug bool) (app.BaseApp, error) {
+
+	ctx := context.Background()
+	kv, err := CommitKVStore(dbPath)
+	if err != nil {
+		return app.BaseApp{}, err
+	}
+	store := app.NewStoreApp(name, kv, QueryRouter(), ctx)
+	base := app.NewBaseApp(store, tx, h, nil, debug)
+	return base, nil
 }

--- a/app/app.go
+++ b/app/app.go
@@ -31,3 +31,11 @@ func Chain(authFn x.Authenticator, minFee coin.Coin) app.Decorators {
 		msgfee.NewFeeDecorator(),
 	)
 }
+
+// Router returns a default router
+func Router(authFn x.Authenticator) app.Router {
+	r := app.NewRouter()
+	// TODO implement orderbook router
+	return r
+}
+

--- a/app/app.go
+++ b/app/app.go
@@ -1,13 +1,15 @@
 package app
 
 import (
+	"github.com/iov-one/weave"
 	"github.com/iov-one/weave/app"
 	"github.com/iov-one/weave/coin"
+	"github.com/iov-one/weave/orm"
 	"github.com/iov-one/weave/x"
+	"github.com/iov-one/weave/x/msgfee"
 	"github.com/iov-one/weave/x/multisig"
 	"github.com/iov-one/weave/x/sigs"
 	"github.com/iov-one/weave/x/utils"
-	"github.com/iov-one/weave/x/msgfee"
 )
 
 // Authenticator returns authentication with multisigs
@@ -19,7 +21,7 @@ func Authenticator() x.Authenticator {
 // Chain returns a chain of decorators, to handle authentication,
 // fees, logging, and recovery
 func Chain(authFn x.Authenticator, minFee coin.Coin) app.Decorators {
-	
+
 	// TODO implement orderbook controller
 	return app.ChainDecorators(
 		utils.NewLogging(),
@@ -39,3 +41,14 @@ func Router(authFn x.Authenticator) app.Router {
 	return r
 }
 
+// QueryRouter returns a default query router,
+// allowing access to "/auth", "/contracts" and "/"
+func QueryRouter() weave.QueryRouter {
+	r := weave.NewQueryRouter()
+	r.RegisterAll(
+		sigs.RegisterQuery,
+		multisig.RegisterQuery,
+		orm.RegisterQuery,
+	)
+	return r
+}

--- a/app/testdata/app.go
+++ b/app/testdata/app.go
@@ -1,0 +1,1 @@
+package fixtures

--- a/app/testdata/app.go
+++ b/app/testdata/app.go
@@ -1,1 +1,28 @@
 package fixtures
+
+import (
+	"fmt"
+	"math/rand"
+
+	"github.com/iov-one/weave"
+	"github.com/iov-one/weave/crypto"
+)
+
+type AppFixture struct {
+	Name              string
+	ChainID           string
+	GenesisKey        *crypto.PrivateKey
+	GenesisKeyAddress weave.Address
+}
+
+func NewApp() *AppFixture {
+	pk := crypto.GenPrivKeyEd25519()
+	addr := pk.PublicKey().Address()
+	name := fmt.Sprint("test-%d", rand.Intn(99999999))
+	return &AppFixture{
+		Name:              name,
+		ChainID:           fmt.Sprint("chain-%s", name),
+		GenesisKey:        pk,
+		GenesisKeyAddress: addr,
+	}
+}


### PR DESCRIPTION
I was implementing init.go(#26)  then I noticed it need to wire together the app to have a clear understanding. My questions are will be on discussions.
__Tests will be implemented after init.go file is implemented__ The reason is: best test structure for app.go is under bnsd with Testdata fixtures. Test data fixtures depend on [init.go](#24) to be implemented. [reference](https://github.com/iov-one/weave/blob/master/cmd/bnsd/app/testdata/fixtures/app.go#L44)